### PR TITLE
Adding secret engine

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,114 @@
 
 
 [[projects]]
+  digest = "1:27624bba723a2ffb12ce7b004b9ada9e9f642951aad1e9947bf4b6f65ee3e8e6"
+  name = "github.com/go-playground/locales"
+  packages = [
+    ".",
+    "currency",
+  ]
+  pruneopts = "UT"
+  revision = "f63010822830b6fe52288ee52d5a1151088ce039"
+  version = "v0.12.1"
+
+[[projects]]
+  digest = "1:e022cf244bcac1b6ef933f1a2e0adcf6a6dfd7b872d8d41e4d4179bb09a87cbc"
+  name = "github.com/go-playground/universal-translator"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
+  version = "v0.16.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d1971637b21871ec2033a44ca87c99c5608a7340cb34ec75fab8d2ab503276c9"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
+
+[[projects]]
+  branch = "master"
+  digest = "1:77cb3be9b21ba7f1a4701e870c84ea8b66e7d74c7c8951c58155fdadae9414ec"
+  name = "github.com/hashicorp/go-cleanhttp"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
+
+[[projects]]
+  branch = "master"
+  digest = "1:46fb6a9f1b9667f32ac93e08b1da118b2c666991424ea12e848b05d4fe5155ef"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
+
+[[projects]]
+  branch = "master"
+  digest = "1:183f00c472fb9b2446659618eebf4899872fa267b92f926539411abdc8b941df"
+  name = "github.com/hashicorp/go-retryablehttp"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+
+[[projects]]
+  branch = "master"
+  digest = "1:35e9b9d8a799b6d4d4196f19cba3b0ffabf3c96b43eaedf388263d033c066616"
+  name = "github.com/hashicorp/go-rootcerts"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
+
+[[projects]]
+  branch = "master"
+  digest = "1:14f2005c31ddf99c4a0f36fc440f8d1ac43224194c7c4a904b3c8f4ba5654d0b"
+  name = "github.com/hashicorp/go-sockaddr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6d291a969b86c4b633730bfc6b8b9d64c3aafed9"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8951fe6e358876736d8fa1f3992624fdbb2dec6bc49401c1381d1ef8abbb544f"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = "UT"
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
+
+[[projects]]
+  digest = "1:8379c00025964094dba71e83ce027e2a37bb9e96c7ac20a806159525b1b871af"
+  name = "github.com/hashicorp/vault"
+  packages = [
+    "api",
+    "helper/compressutil",
+    "helper/hclutil",
+    "helper/jsonutil",
+    "helper/parseutil",
+    "helper/strutil",
+  ]
+  pruneopts = "UT"
+  revision = "e21712a687889de1125e0a12a980420b1a4f72d3"
+  version = "v0.10.4"
+
+[[projects]]
   branch = "master"
   digest = "1:57ba20adfa43f47872d3577fb6e88dd54472ad19f79f95b1975ed87bfe028c45"
   name = "github.com/hpcloud/tail"
@@ -14,6 +122,22 @@
   ]
   pruneopts = "UT"
   revision = "a1dbeea552b7c8df4b542c66073e393de198a800"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c7354463195544b1ab3c1f1fadb41430947f5d28dfbf2cdbd38268c5717a5a03"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "58046073cbffe2f25d425fe1331102f55cf719de"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5ab79470a1d0fb19b041a624415612f8236b3c06070161a910562f2b2d064355"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
   digest = "1:b1fc68069736db92aefa48adf2dcb7e16d23d13425c8ae80ca600281f7d711b3"
@@ -64,6 +188,14 @@
   version = "v1.4.1"
 
 [[projects]]
+  digest = "1:0e792eea6c96ec55ff302ef33886acbaa5006e900fefe82689e88d96439dcd84"
+  name = "github.com/ryanuber/go-glob"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
+  version = "v0.1"
+
+[[projects]]
   digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -81,12 +213,17 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6bab46a020b433450836f84254204364dbce7da8fd944a8c2c40e294b4160826"
+  digest = "1:946b4cb3e8af220817f220df719f9af0f12cd7f84dc9f3e22bdc320853576af1"
   name = "golang.org/x/net"
   packages = [
+    "context",
     "html",
     "html/atom",
     "html/charset",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
   ]
   pruneopts = "UT"
   revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
@@ -103,9 +240,11 @@
   revision = "ac767d655b305d4e9612f5f6e33120b9176c4ad4"
 
 [[projects]]
-  digest = "1:00b52d21f87065cee85096f07ba40957cc53719145c224da5f5d113669868213"
+  digest = "1:1593eb192a256b34419f8e8765d0b0e15f47399a3c32a08b242632b2928391cb"
   name = "golang.org/x/text"
   packages = [
+    "collate",
+    "collate/build",
     "encoding",
     "encoding/charmap",
     "encoding/htmlindex",
@@ -116,17 +255,32 @@
     "encoding/simplifiedchinese",
     "encoding/traditionalchinese",
     "encoding/unicode",
+    "internal/colltab",
     "internal/gen",
     "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
     "internal/utf8internal",
     "language",
     "runes",
+    "secure/bidirule",
     "transform",
+    "unicode/bidi",
     "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
   ]
   pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "UT"
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -135,6 +289,14 @@
   pruneopts = "UT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
+
+[[projects]]
+  digest = "1:e2f64cca6e235f32cd4c2f9be9ae0cda1f8608fc6fdb68936e8d10e4e0bb074d"
+  name = "gopkg.in/go-playground/validator.v9"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e69e9a28bb62b977fdc58d051f1bb477b7cbe486"
+  version = "v9.21.0"
 
 [[projects]]
   digest = "1:3c839a777de0e6da035c9de900b60cbec463b0a89351192c1ea083eaf9e0fce0"
@@ -155,9 +317,11 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/hashicorp/vault/api",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "github.com/sirupsen/logrus",
+    "gopkg.in/go-playground/validator.v9",
     "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,3 +44,11 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "gopkg.in/go-playground/validator.v9"
+  version = "9.21.0"
+
+[[constraint]]
+  name = "github.com/hashicorp/vault"
+  version = "0.10.4"

--- a/README.md
+++ b/README.md
@@ -103,3 +103,13 @@ kubernetes:
           port: 9090
           name: openport
  ```
+
+Loading a variable from a running vault instance.
+```
+env:
+    API_KEY: {{ vaultsecret "/secret/path/to/secret" "keyInDataMap" }}
+```
+
+For this to work, you will need to have:
+- VAULT_ADDR exported in your shell to the running vault instance
+- VAULT_TOKEN exported in your shell if "${HOME}/.vault-token" isn't present

--- a/example/bar/skip.yml
+++ b/example/bar/skip.yml
@@ -1,4 +1,0 @@
----
-# Should be skipped due to be being a wrong file extension
-
-Item : {{ .ShouldExplode }}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ var (
 	templatePath string
 	variablePath string
 	outputPath   string
+	filter       string
 	debug        bool
 	validate     bool
 	vortex       = processor.New()
@@ -46,6 +47,7 @@ func init() {
 	flag.StringVar(&outputPath, "output", "./", "Output path for the rendered templates to be outputted")
 	flag.BoolVar(&validate, "validate", false, "validate syntax and check for the required variables")
 	flag.BoolVar(&debug, "verbose", false, "enable verbose logging")
+	flag.StringVar(&filter, "filter", "ya?ml$", "Allows for filtered parsing of directories")
 	flag.Var(flag.Value(vortex), "set", "Add additional variables via the command line in the format of \"key=value\" or valid json/yaml")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, usage, os.Args[0], os.Args[0])
@@ -56,7 +58,8 @@ func init() {
 func main() {
 	flag.Parse()
 	vortex = vortex.EnableDebug(debug).
-		EnableStrict(validate)
+		EnableStrict(validate).
+		SetFilter(filter)
 	if err := vortex.LoadVariables(variablePath); err != nil {
 		log.Warn("Unable to load variables due to", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -61,11 +61,11 @@ func main() {
 		EnableStrict(validate).
 		SetFilter(filter)
 	if err := vortex.LoadVariables(variablePath); err != nil {
-		log.Warn("Unable to load variables due to", err)
+		log.Warn("Unable to load variables due to ", err)
 		os.Exit(1)
 	}
 	if err := vortex.ProcessTemplates(templatePath, outputPath); err != nil {
-		log.Warn("Unable to process templates due to", err)
+		log.Warn("Unable to process templates due to ", err)
 		os.Exit(1)
 	}
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -96,8 +96,12 @@ func (v *vortex) ProcessTemplates(templateroot, outputroot string) error {
 		readpath := path.Join(templateroot, file.Name())
 		switch {
 		// Ensure we don't automatically recurse down hidden files
-		case file.IsDir() && !strings.HasPrefix(file.Name(), "."):
+		case file.IsDir():
 			newroot := path.Join(outputroot, file.Name())
+			if strings.HasPrefix(file.Name(), ".") {
+				v.logMessage("Skipping hidden file: ", newroot)
+				continue
+			}
 			if err := v.ProcessTemplates(readpath, newroot); err != nil {
 				return err
 			}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -7,10 +7,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"text/template"
-	"regexp"
 
+	"github.com/AlexsJones/vortex/secrets"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -25,7 +26,7 @@ type vortex struct {
 func New() *vortex {
 	return &vortex{
 		variables: map[string]interface{}{},
-		filter: regexp.MustCompile(`.ya?ml$`),
+		filter:    regexp.MustCompile(`.ya?ml$`),
 	}
 }
 
@@ -150,7 +151,11 @@ func (v *vortex) processTemplate(templatepath, outputpath string) error {
 	if err != nil {
 		return err
 	}
-	tmpl, err := template.New(path.Base(templatepath)).Parse(string(buff))
+	tmpl, err := template.New(path.Base(templatepath)).
+		Funcs(template.FuncMap{
+			"vaultsecret": secrets.VaultFetchSecret,
+		}).
+		Parse(string(buff))
 	if err != nil {
 		return err
 	}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -18,11 +18,13 @@ type vortex struct {
 	variables map[string]interface{}
 	strict    bool
 	debug     bool
+	filter    *regexp.Regexp
 }
 
 func New() *vortex {
 	return &vortex{
 		variables: map[string]interface{}{},
+		filter: regexp.MustCompile(`.ya?ml$`),
 	}
 }
 
@@ -70,6 +72,15 @@ func (v *vortex) LoadVariables(variablepath string) error {
 func (v *vortex) EnableStrict(enable bool) *vortex {
 	v.strict = enable
 	return v
+}
+
+func (v *vortex) SetFilter(filter string) *vortex {
+	v.filter = regexp.MustCompile(filter)
+	return v
+}
+
+func (v *vortex) canProcess(templatepath string) bool {
+	return v.filter.MatchString(templatepath)
 }
 
 // ProcessTemplates applys a DFS over the templateroot and will process the

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -128,6 +128,10 @@ func (v *vortex) ProcessTemplates(templateroot, outputroot string) error {
 }
 
 func (v *vortex) processTemplate(templatepath, outputpath string) error {
+	if !v.canProcess(templatepath) {
+		v.logMessage("Can not process: ", templatepath)
+		return nil
+	}
 	// if the folder path doesn't exist, then we need to make it
 	// and make sure we don't create a directory if we are just validating the contents
 	if _, err := os.Stat(outputpath); os.IsNotExist(err) && !v.strict {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -112,9 +112,6 @@ func (v *vortex) ProcessTemplates(templateroot, outputroot string) error {
 }
 
 func (v *vortex) processTemplate(templatepath, outputpath string) error {
-	if !strings.HasSuffix(templatepath, ".yaml") {
-		return nil
-	}
 	// if the folder path doesn't exist, then we need to make it
 	// and make sure we don't create a directory if we are just validating the contents
 	if _, err := os.Stat(outputpath); os.IsNotExist(err) && !v.strict {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 	"text/template"
+	"regexp"
 
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"

--- a/secrets/vault.go
+++ b/secrets/vault.go
@@ -1,0 +1,71 @@
+package secrets
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+
+	"github.com/hashicorp/vault/api"
+	validator "gopkg.in/go-playground/validator.v9"
+)
+
+var (
+	validate = validator.New()
+)
+
+type vault struct {
+	token   string `validate:"required"`
+	address string `validate:"required"`
+}
+
+// NewVaultFromEnv creates a vault SecretObtainer
+// using the usual environment settings that the vault cli would use.
+func NewVaultFromEnv() (*vault, error) {
+	v := &vault{
+		address: "http://localhost:8200",
+	}
+	if usr, err := user.Current(); err != nil {
+		if f, err := os.Open(path.Join(usr.HomeDir, ".vault-token")); os.IsExist(err) {
+			buff, err := ioutil.ReadAll(f)
+			if err != nil {
+				return nil, err
+			}
+			v.token = string(buff)
+		}
+	}
+	if token, set := os.LookupEnv("VAULT_TOKEN"); set && len(v.token) == 0 {
+		v.token = token
+	}
+	if addr, set := os.LookupEnv("VAULT_ADDR"); set {
+		v.address = addr
+	}
+	return v, validate.Struct(v)
+}
+
+func VaultFetchSecret(storepath, key string) (string, error) {
+	v, err := NewVaultFromEnv()
+	if err != nil {
+		return "", err
+	}
+	client, err := api.NewClient(&api.Config{
+		Address: v.address,
+	})
+	if err != nil {
+		return "", err
+	}
+	client.SetToken(v.token)
+	data, err := client.Logical().Read(storepath)
+	if err != nil {
+		return "", err
+	}
+	if data == nil || data.Data == nil {
+		return "", errors.New("No data returned for the given key")
+	}
+	if _, exist := data.Data[key]; !exist {
+		return "", errors.New("Key does not exist inside the returned data map")
+	}
+	// Sneaky like the ninja
+	return data.Data[key].(string), nil
+}


### PR DESCRIPTION
This pr looks to add `vaultsecret` as an additional function to vortex as its processing templates.

By default, the vault settings are loaded from the environment, the same way vault would read the environment.

To use vault in a template, you simply need to:
```
{{ vaultsecret "/secret/path/to/secret/store" "keyInMap" }}
```