### PR TITLE
Use vault's token helper instead of homebrew solution

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,21 +2,6 @@
 
 
 [[projects]]
-  name = "github.com/go-playground/locales"
-  packages = [
-    ".",
-    "currency"
-  ]
-  revision = "f63010822830b6fe52288ee52d5a1151088ce039"
-  version = "v0.12.1"
-
-[[projects]]
-  name = "github.com/go-playground/universal-translator"
-  packages = ["."]
-  revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
-  version = "v0.16.0"
-
-[[projects]]
   branch = "master"
   name = "github.com/golang/snappy"
   packages = ["."]
@@ -243,12 +228,6 @@
   version = "v1.4.7"
 
 [[projects]]
-  name = "gopkg.in/go-playground/validator.v9"
-  packages = ["."]
-  revision = "e69e9a28bb62b977fdc58d051f1bb477b7cbe486"
-  version = "v9.21.0"
-
-[[projects]]
   name = "gopkg.in/tomb.v1"
   packages = ["."]
   revision = "c131134a1947e9afd9cecfe11f4c6dff0732ae58"
@@ -262,6 +241,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a42cdd2d823eb7989272a342e0ffe28adee89f0fb68c559ebe3203a06620725e"
+  inputs-digest = "c25bda2c9be2544c8847d1694b7b98e11854ce8017de0144ce8772a762c4ade6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,9 +46,5 @@
   unused-packages = true
 
 [[constraint]]
-  name = "gopkg.in/go-playground/validator.v9"
-  version = "9.21.0"
-
-[[constraint]]
   name = "github.com/hashicorp/vault"
   version = "0.10.4"

--- a/secrets/vault.go
+++ b/secrets/vault.go
@@ -2,57 +2,33 @@ package secrets
 
 import (
 	"errors"
-	"io/ioutil"
-	"os"
-	"path"
 
 	"github.com/hashicorp/vault/api"
-	validator "gopkg.in/go-playground/validator.v9"
+	"github.com/hashicorp/vault/command/config"
 )
-
-var (
-	validate = validator.New()
-)
-
-type vault struct {
-	token   string `validate:"required"`
-	address string `validate:"gt=1"`
-}
-
-// NewVaultFromEnv creates a vault SecretObtainer
-// using the usual environment settings that the vault cli would use.
-func NewVaultFromEnv() (*vault, error) {
-	v := &vault{
-		address: "http://localhost:8200",
-	}
-	if f, err := os.Open(path.Join(os.Getenv("HOME"), ".vault-token")); !os.IsNotExist(err) {
-		buff, err := ioutil.ReadAll(f)
-		if err != nil {
-			return nil, err
-		}
-		v.token = string(buff)
-	}
-	if token, set := os.LookupEnv("VAULT_TOKEN"); set && len(v.token) == 0 {
-		v.token = token
-	}
-	if addr, set := os.LookupEnv("VAULT_ADDR"); set {
-		v.address = addr
-	}
-	return v, validate.Struct(v)
-}
 
 func VaultFetchSecret(storepath, key string) (string, error) {
-	v, err := NewVaultFromEnv()
+	client, err := api.NewClient(nil)
 	if err != nil {
 		return "", err
 	}
-	client, err := api.NewClient(&api.Config{
-		Address: v.address,
-	})
-	if err != nil {
-		return "", err
+
+	if client.Token() == "" {
+		helper, err := config.DefaultTokenHelper()
+		if err != nil {
+			return "", err
+		}
+
+		token, err := helper.Get()
+		if err != nil {
+			return "", err
+		}
+
+		if token != "" {
+			client.SetToken(token)
+		}
 	}
-	client.SetToken(v.token)
+
 	data, err := client.Logical().Read(storepath)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
I noticed when we were looking at Vortex earlier that the vault implementation was reimplementing vault's login for finding the correct vault token and address

`api.NewClient(nil)` uses the default config, which looks in the VAULT_ADDR and VAULT_TOKEN environment variables, and `config.DefaultTokenHelper()` gets the Token helper which by default looks in `~/.vault-token`. (Confusingly, if you have a custom token helper defined in vault config, it seems DefaultTokenHelper will actually return that, not the default).

I might have missed something else from the previous implementation, but from testing it seems like this should work basically the same, but also work for people with custom vault token helpers