### PR TITLE
Add --varpath-config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ roleRef:
   name: view
   apiGroup: ""
  ```
- 
+
 ### Loading a variable from a connected vault instance.
 ```
 env:
@@ -151,3 +151,44 @@ annotations:
 ```
 This enables secrets to be loaded via environment variables rather than alternative methods such as using `sed` over
 the template before processing.
+
+## VarpathConfig Example
+
+demo.yaml
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: console
+spec:
+  restartPolicy: Always
+  containers:
+    - name: {{.name}}
+      image: us.gcr.io/test:{{.tag}}
+
+```
+
+vars.yaml
+```
+name: "test"
+tag: {{.jobid}}
+```
+
+Run vortex:
+```
+export JOB_ID=1234
+vortex --template ./demo.tmpl --varpath-config "{\"jobid\":\"$JOB_ID\"}" --output ./deployment -varpath ./vars.yaml
+```
+
+The result;
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: console
+spec:
+  restartPolicy: Always
+  containers:
+    - name: test
+      image: us.gcr.io/test
+````

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ The flags being used are:
 var (
 	templatePath     string
 	variablePath     string
-	overrideVariable string
+	defaultVariable string
 	outputPath       string
 	filter           string
 	validator        string
@@ -46,7 +46,7 @@ func init() {
 	)
 	flag.StringVar(&templatePath, "template", blank, "path to the the directory or file to process")
 	flag.StringVar(&variablePath, "varpath", blank, "path to the variable config to use while processing")
-	flag.StringVar(&overrideVariable, "override-var", blank, "Json object that overrides values defined on variable-path")
+	flag.StringVar(&defaultVariable, "defaultvar", blank, "Json object that overrides values defined on variable-path")
 	flag.StringVar(&outputPath, "output", "./", "Output path for the rendered templates to be outputted")
 	flag.BoolVar(&validate, "validate", false, "validate syntax and check for the required variables")
 	flag.BoolVar(&debug, "verbose", false, "enable verbose logging")
@@ -65,7 +65,7 @@ func main() {
 		EnableStrict(validate).
 		SetValidator(validator).
 		SetFilter(filter)
-	if err := vortex.LoadVariables(variablePath, overrideVariable); err != nil {
+	if err := vortex.LoadVariables(variablePath, defaultVariable); err != nil {
 		log.Warn("Unable to load variables due to ", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ The flags being used are:
 var (
 	templatePath     string
 	variablePath     string
-	defaultVariable string
+	variableConfig string
 	outputPath       string
 	filter           string
 	validator        string
@@ -46,7 +46,7 @@ func init() {
 	)
 	flag.StringVar(&templatePath, "template", blank, "path to the the directory or file to process")
 	flag.StringVar(&variablePath, "varpath", blank, "path to the variable config to use while processing")
-	flag.StringVar(&defaultVariable, "defaultvar", blank, "Json object that overrides values defined on variable-path")
+	flag.StringVar(&variableConfig, "varpath-config", blank, "Json object that configures variable-path template")
 	flag.StringVar(&outputPath, "output", "./", "Output path for the rendered templates to be outputted")
 	flag.BoolVar(&validate, "validate", false, "validate syntax and check for the required variables")
 	flag.BoolVar(&debug, "verbose", false, "enable verbose logging")
@@ -65,7 +65,7 @@ func main() {
 		EnableStrict(validate).
 		SetValidator(validator).
 		SetFilter(filter)
-	if err := vortex.LoadVariables(variablePath, defaultVariable); err != nil {
+	if err := vortex.LoadVariables(variablePath, variableConfig); err != nil {
 		log.Warn("Unable to load variables due to ", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -29,14 +29,15 @@ The flags being used are:
 )
 
 var (
-	templatePath string
-	variablePath string
-	outputPath   string
-	filter       string
-	validator    string
-	debug        bool
-	validate     bool
-	vortex       = processor.New()
+	templatePath     string
+	variablePath     string
+	overrideVariable string
+	outputPath       string
+	filter           string
+	validator        string
+	debug            bool
+	validate         bool
+	vortex           = processor.New()
 )
 
 func init() {
@@ -45,6 +46,7 @@ func init() {
 	)
 	flag.StringVar(&templatePath, "template", blank, "path to the the directory or file to process")
 	flag.StringVar(&variablePath, "varpath", blank, "path to the variable config to use while processing")
+	flag.StringVar(&overrideVariable, "override-var", blank, "Json object that overrides values defined on variable-path")
 	flag.StringVar(&outputPath, "output", "./", "Output path for the rendered templates to be outputted")
 	flag.BoolVar(&validate, "validate", false, "validate syntax and check for the required variables")
 	flag.BoolVar(&debug, "verbose", false, "enable verbose logging")
@@ -63,7 +65,7 @@ func main() {
 		EnableStrict(validate).
 		SetValidator(validator).
 		SetFilter(filter)
-	if err := vortex.LoadVariables(variablePath); err != nil {
+	if err := vortex.LoadVariables(variablePath, overrideVariable); err != nil {
 		log.Warn("Unable to load variables due to ", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -29,15 +29,15 @@ The flags being used are:
 )
 
 var (
-	templatePath     string
-	variablePath     string
+	templatePath   string
+	variablePath   string
 	variableConfig string
-	outputPath       string
-	filter           string
-	validator        string
-	debug            bool
-	validate         bool
-	vortex           = processor.New()
+	outputPath     string
+	filter         string
+	validator      string
+	debug          bool
+	validate       bool
+	vortex         = processor.New()
 )
 
 func init() {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -78,12 +78,12 @@ func (v *vortex) LoadVariables(variablepath string, variablesConfig string) erro
 	if err != nil {
 		return err
 	}
-	templatedbuff := v.templateVar(buff, variablesConfig)
+	templatedbuff := v.templateVarpath(buff, variablesConfig)
 
 	return yaml.Unmarshal(templatedbuff, &(v.variables))
 }
 
-func (v *vortex) templateVar(buff []byte, vars string) []byte {
+func (v *vortex) templateVarpath(buff []byte, vars string) []byte {
 	if vars == "" {
 		return buff
 	}


### PR DESCRIPTION
Idea:
 - Previous functionality is the same (no breaking changes)
 - You can use a template on your varpath and use --varpath-config to pass the values

Example:
```
vortex --template ../templates --varpath-config "{\"environment\":\"$ENVIRONMENT\",\"slackhook\":\"$SLACKHOOK\",\"imagetag\":\"$PIPELINE_ID\"}" --output ../deployment -varpath ./default.yaml -verbose
```